### PR TITLE
fin

### DIFF
--- a/lib/paragraph_truncator.rb
+++ b/lib/paragraph_truncator.rb
@@ -2,4 +2,11 @@
 # amount, with some indication of the truncating (a "..." by default).
 
 def truncate_paragraph(long_str, num_characters, truncated_indicator="...")
+arr=long_str.split("") # split string into array
+goal_trunc = arr.length-num_characters #get length of array minus how many letters to leave displaying
+arr.slice!(num_characters..arr.length) #starting from indicating position slice off until the end of the array  
+puts arr.join + truncated_indicator #convert arr back to str and add indicator
 end
+
+
+


### PR DESCRIPTION
Below is the error I receive when trying to rake this code

➜  ruby-toy__paragraph-truncator git:(master) rake
/Users/mac/.rbenv/versions/2.3.0/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- minitest/rg (LoadError)
    from /Users/mac/.rbenv/versions/2.3.0/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in`require'
    from /Users/mac/Code/ruby-toy__paragraph-truncator/tests/test_helper.rb:1:in `<top (required)>'
    from /Users/mac/.rbenv/versions/2.3.0/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in`require'
    from /Users/mac/.rbenv/versions/2.3.0/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /Users/mac/Code/ruby-toy__paragraph-truncator/tests/paragraph_truncator_test.rb:1:in`<top (required)>'
    from /Users/mac/.rbenv/versions/2.3.0/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /Users/mac/.rbenv/versions/2.3.0/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in`require'
    from /Users/mac/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rake-10.5.0/lib/rake/rake_test_loader.rb:10:in `block (2 levels) in <main>'
    from /Users/mac/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rake-10.5.0/lib/rake/rake_test_loader.rb:9:in`each'
    from /Users/mac/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rake-10.5.0/lib/rake/rake_test_loader.rb:9:in `block in <main>'
    from /Users/mac/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rake-10.5.0/lib/rake/rake_test_loader.rb:4:in`select'
    from /Users/mac/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rake-10.5.0/lib/rake/rake_test_loader.rb:4:in `<main>'
rake aborted!
Command failed with status (1): [ruby -I"lib:tests" -I"/Users/mac/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rake-10.5.0/lib" "/Users/mac/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rake-10.5.0/lib/rake/rake_test_loader.rb" "tests/*_/__test.rb" ]

Tasks: TOP => default => test
(See full trace by running task with --trace)
